### PR TITLE
Search improvements: Replace fuzzy matching with tsvector

### DIFF
--- a/api/alembic/versions/7a0e2fa127ab_create_fts_gin_index_on_book_title.py
+++ b/api/alembic/versions/7a0e2fa127ab_create_fts_gin_index_on_book_title.py
@@ -1,0 +1,38 @@
+"""create fts gin index on book title
+
+Revision ID: 7a0e2fa127ab
+Revises: dbc0439ca2e9
+Create Date: 2025-07-13 15:51:13.709388
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7a0e2fa127ab'
+down_revision: Union[str, None] = 'dbc0439ca2e9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute(
+        """
+        CREATE INDEX book_title_fts_idx
+        ON books
+        USING gin(to_tsvector('english', title));
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute(
+        """
+        DROP INDEX IF EXISTS book_title_fts_idx;
+        """
+    )

--- a/api/src/books/application/repositories/book_repository.py
+++ b/api/src/books/application/repositories/book_repository.py
@@ -68,7 +68,7 @@ class AbstractBookRepo(ABC):
         pass
 
     @abstractmethod
-    def search_books(self, query: str, page_size: int, page: int = 1, threshold: float = 0.5) -> list[Book]:
+    def search_books(self, query: str, page_size: int, page: int = 1) -> list[Book]:
         """
         Search for books.
         :param query: The query to search for.

--- a/api/src/books/application/use_cases/search_books.py
+++ b/api/src/books/application/use_cases/search_books.py
@@ -55,9 +55,7 @@ class SearchBooks:
             # Multiply by 2 to account for duplicates
             self._process_external_books(query, external_books_needed * 2)
             db_books = self.book_repository.search_books(query, page_size)
-        for book in db_books:
-            print(book.title)
-            print(book.authors)
+
         has_more = len(db_books) == page_size + 1
 
         # Only return up to page_size books

--- a/api/src/books/infrastructure/repositories/book_repo.py
+++ b/api/src/books/infrastructure/repositories/book_repo.py
@@ -153,6 +153,8 @@ class BookRepo(AbstractBookRepo):
         :param threshold: The threshold for the similarity search.
         :return: A list of book objects.
         """
+        # TODO: ts matches exactly on tokens, so it doesn't allow for spelling mistakes etc. 
+        # Consider using trigram as a fallback or move to a dedicated search service (e.g. typesense)
         result = (self.session.query(BookModel)
             .filter(func.to_tsvector('english', BookModel.title)
                 .op('@@')(func.plainto_tsquery('english', query)))

--- a/api/src/books/infrastructure/repositories/book_repo.py
+++ b/api/src/books/infrastructure/repositories/book_repo.py
@@ -154,8 +154,12 @@ class BookRepo(AbstractBookRepo):
         :return: A list of book objects.
         """
         result = (self.session.query(BookModel)
-            .filter(func.similarity(BookModel.title, query) > threshold)
-            .order_by(func.similarity(BookModel.title, query).desc())
+            .filter(func.to_tsvector('english', BookModel.title)
+                .op('@@')(func.plainto_tsquery('english', query)))
+            .order_by(func.ts_rank(
+                func.to_tsvector('english', BookModel.title),
+                func.plainto_tsquery('english', query)
+                ).desc())
             .offset((page - 1) * page_size)
             .limit(page_size + 1)
             .all())

--- a/api/src/books/infrastructure/repositories/book_repo.py
+++ b/api/src/books/infrastructure/repositories/book_repo.py
@@ -144,7 +144,7 @@ class BookRepo(AbstractBookRepo):
         })
         self.session.commit()
 
-    def search_books(self, query: str, page_size: int, page: int = 1, threshold: float = 0.2) -> list[Book]:
+    def search_books(self, query: str, page_size: int, page: int = 1) -> list[Book]:
         """
         Search for books by title. Note that we return one more book than the page size to check if there are more books.
         :param query: The query to search for.


### PR DESCRIPTION
We're currently using fuzzy matching to match book titles to search queries. This leads to problems as, when a book title is much longer than the search query, fuzzy matching will determine that the two are too dissimilar to be a match, whereas other titles that may not be in any way similar to the search query apart from in length do get matched. 

The current solution to this is to use postgresql's tsvector function. We filter the books table by turning the titles into ts vectors of searchable tokens, convert the search query to tokens and check whether tokens in the search query are present in the title. This works better than fuzzy matching when spelling is correct, but does fall apart for partial words and spelling mistakes. 

In the future, we may want to move to a dedicated search service 