### PR TITLE
Search bug: Fix authors' names not showing

### DIFF
--- a/ui/src/components/BookCard.tsx
+++ b/ui/src/components/BookCard.tsx
@@ -43,7 +43,7 @@ export default function BookCard({
 
         <Stack justify="space-between" h="100%" style={{ flex: 1 }}>
           <Text fw={500} size="lg">{title}</Text>
-          <Text>{authors.map((author) => author.name).join(", ")}</Text>
+          <Text>{authors.join(", ")}</Text>
 
           <BookActions
             bookId={id}

--- a/ui/src/types/author.ts
+++ b/ui/src/types/author.ts
@@ -1,4 +1,0 @@
-export type TAuthor = {
-    id: string;
-    name: string;
-}

--- a/ui/src/types/book.ts
+++ b/ui/src/types/book.ts
@@ -1,8 +1,6 @@
-import { TAuthor } from "./author";
-
 export type TBook = {
     title: string;
-    authors: TAuthor[];
+    authors: string[];
     average_love_rating: number;
     average_shit_rating: number;
     number_of_ratings: number;


### PR DESCRIPTION
Due to the recently added BookSearchResponse returning authors as a list of names rather than a list of author objects, the author display on the front end broke. The frontend now expects authors to simply be names in all current cases, and the author type has been removed (we can add it again in the future if need be)