### PR TITLE
Search improvements: fetch more external results

### DIFF
--- a/api/src/books/api/dependencies.py
+++ b/api/src/books/api/dependencies.py
@@ -1,5 +1,6 @@
-from fastapi import Depends
+from fastapi import BackgroundTasks, Depends
 
+from src.infrastructure.services.background_task_queue import FastAPIBackgroundTaskQueue
 from src.books.infrastructure.repositories.author_repo import AuthorRepo
 from src.books.application.use_cases.search_books import SearchBooks
 from src.books.application.use_cases.get_book_details import GetBookDetails
@@ -70,6 +71,7 @@ def search_books_use_case(
     book_repo=Depends(get_books_repo), 
     external_books_service=Depends(get_external_books_service), 
     author_repo=Depends(get_authors_repo), 
+    background_tasks: BackgroundTasks = None
 ):
     """
     Dependency to provide the SearchBooks use case.
@@ -78,4 +80,5 @@ def search_books_use_case(
         book_repository=book_repo, 
         external_books_service=external_books_service, 
         author_repository=author_repo, 
+        background_task_queue=FastAPIBackgroundTaskQueue(background_tasks=background_tasks)
     )

--- a/api/src/books/api/routes.py
+++ b/api/src/books/api/routes.py
@@ -11,7 +11,13 @@ from src.users.api.auth import get_current_user
 router = APIRouter()
 
 @router.get("/")
-async def get_books(get_books=Depends(get_books_use_case), page: int = 1, page_size: int = 10, sort_by: str = "title", sort_order: str = "asc", author_id: UUID = None):
+async def get_books(
+    get_books=Depends(get_books_use_case), 
+    page: int = 1, 
+    page_size: int = 10, 
+    sort_by: str = "title", 
+    sort_order: str = "asc", 
+    author_id: UUID = None):
     """
     Get all books.
     """

--- a/api/src/books/api/routes.py
+++ b/api/src/books/api/routes.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends
 
 from src.books.api.dependencies import get_book_details_use_case, get_books_use_case, rate_book_use_case, review_book_use_case, search_books_use_case
 from src.books.api.schemas.book_search_response import BookSearchResponse
@@ -27,6 +27,7 @@ async def get_books(
 @router.get("/search")
 async def search_books(
         query: str,
+        background_tasks: BackgroundTasks,
         search_books=Depends(search_books_use_case),
         page_size: int = 10,
         page: int = 1) -> BookSearchResponse:

--- a/api/src/books/application/services/external_books_service.py
+++ b/api/src/books/application/services/external_books_service.py
@@ -5,6 +5,13 @@ from src.books.domain.models import Book
 
 class AbstractBooksService(ABC):
     @abstractmethod
-    def search_books(self, query: str, page_size: int) -> list[Book]:
+    def search_books(self, query: str, page_size: int, start_index: int) -> list[Book]:
+        """
+        Search for books by title from an external api.
+        :param query: The query to search for.
+        :param page_size: The number of books per page.
+        :param start_index: The index of the first book to return.
+        :return: A list of book objects.
+        """
         pass
 

--- a/api/src/books/application/use_cases/search_books.py
+++ b/api/src/books/application/use_cases/search_books.py
@@ -10,8 +10,8 @@ class SearchBooks:
         self.external_books_service = external_books_service
         self.author_repository = author_repository
 
-    def _process_external_books(self, query: str, page_size: int):
-        external_books = self.external_books_service.search_books(query, page_size=page_size)
+    def _process_external_books(self, query: str, page_size: int, start_index: int):
+        external_books = self.external_books_service.search_books(query, page_size=page_size, start_index=start_index)
         
         # Search for books that are not in the database and add them to the database
         for external_book in external_books:
@@ -38,23 +38,18 @@ class SearchBooks:
         if page < 1:
             return BookSearchResponse(books=[], has_more=False)
         
-        # For simplicity, just search db for the next page, don't bother with external api
-        if page > 1:
-            db_books = self.book_repository.search_books(query, page_size, page)
-            has_more = len(db_books) == page_size + 1
-            # Only return up to page_size books
-            books_to_return = db_books[:page_size]
-            return BookSearchResponse.from_domain(books_to_return, has_more)
-            
         # We essentially do 2 searches to get the books 
         # If there are enough books the first time, then happy days 
         # Otherwise, we copy data from the external api into the db and do a second search
-        db_books = self.book_repository.search_books(query, page_size)
+        db_books = self.book_repository.search_books(query, page_size, page)
         external_books_needed = page_size - len(db_books)
         if external_books_needed > 0:
             # Multiply by 2 to account for duplicates
-            self._process_external_books(query, external_books_needed * 2)
-            db_books = self.book_repository.search_books(query, page_size)
+            self._process_external_books(query, page_size * 2, page_size * (page - 1))
+            db_books = self.book_repository.search_books(query, page_size, page)
+        else:
+            # Background a task to process the external books
+            pass
 
         has_more = len(db_books) == page_size + 1
 

--- a/api/src/books/infrastructure/services/google_books_api_service.py
+++ b/api/src/books/infrastructure/services/google_books_api_service.py
@@ -9,13 +9,13 @@ class GoogleBooksApiService(AbstractBooksService):
     def __init__(self, author_repo: AbstractAuthorRepo):
         self.author_repo = author_repo
 
-    def search_books(self, query: str, page_size: int = 10) -> list[Book]:
+    def search_books(self, query: str, page_size: int = 10, start_index: int = 0) -> list[Book]:
         books = []
 
         if page_size == 0:
             return books
         
-        books_data = self._get_books_data(query, page_size)
+        books_data = self._get_books_data(query, page_size, start_index)
 
         for book_data in books_data:
             volume_info = book_data.get("volumeInfo", {})
@@ -38,8 +38,8 @@ class GoogleBooksApiService(AbstractBooksService):
 
         return books
 
-    def _get_books_data(self, query: str, page_size: int) -> list[dict]:
-        url = f"https://www.googleapis.com/books/v1/volumes?q={query}&maxResults={page_size}"
+    def _get_books_data(self, query: str, page_size: int, start_index: int) -> list[dict]:
+        url = f"https://www.googleapis.com/books/v1/volumes?q={query}&maxResults={page_size}&startIndex={start_index}"
         response = httpx.get(url)
         response.raise_for_status()
         return response.json().get("items", [])

--- a/api/src/infrastructure/services/background_task_queue.py
+++ b/api/src/infrastructure/services/background_task_queue.py
@@ -1,0 +1,15 @@
+from fastapi import BackgroundTasks
+from abc import ABC, abstractmethod
+
+class BackgroundTaskQueue(ABC):
+    @abstractmethod
+    def add_task(self, func, *args, **kwargs):
+        pass
+
+# TODO: separate this out into a separate file when needed
+class FastAPIBackgroundTaskQueue(BackgroundTaskQueue):
+    def __init__(self, background_tasks: BackgroundTasks):
+        self.background_tasks = background_tasks
+
+    def add_task(self, func, *args, **kwargs):
+        self.background_tasks.add_task(func, *args, **kwargs)

--- a/ui/src/pages/Search.tsx
+++ b/ui/src/pages/Search.tsx
@@ -66,7 +66,7 @@ export default function Search() {
         )}
         {searchResults?.has_more ? (
           <Button onClick={handleLoadMore}>Load more</Button>
-        ) : (
+        ) : accumulatedBooks.length > 0 && !isLoading && (
           <Center>
             <Text size="lg" c="dimmed" ta="center">
               No more books found for "{activeSearch}"

--- a/ui/src/pages/Search.tsx
+++ b/ui/src/pages/Search.tsx
@@ -47,11 +47,6 @@ export default function Search() {
           </Title>
         )}
         <Divider/>
-        {isLoading && (
-          <Center>
-            <Loader size="xl" />
-          </Center>
-        )}
         {accumulatedBooks.length === 0 && activeSearch && !isLoading && (
           <Center>
             <Text size="lg" c="dimmed" ta="center">
@@ -69,8 +64,19 @@ export default function Search() {
             ))}
           </Stack>
         )}
-        {searchResults?.has_more && (
+        {searchResults?.has_more ? (
           <Button onClick={handleLoadMore}>Load more</Button>
+        ) : (
+          <Center>
+            <Text size="lg" c="dimmed" ta="center">
+              No more books found for "{activeSearch}"
+            </Text>
+          </Center>
+        )}
+        {isLoading && (
+          <Center>
+            <Loader size="xl" />
+          </Center>
         )}
       </Stack>
     </Center>

--- a/ui/src/pages/Search.tsx
+++ b/ui/src/pages/Search.tsx
@@ -1,7 +1,7 @@
 import { Center, Stack, Title, Divider, Loader, Text, Button } from "@mantine/core";
 import BookCard from "../components/BookCard";
 import { useBookSearch } from "../hooks/useBooks";
-import { useState, useEffect } from "react";
+import { useState, useEffect, Fragment } from "react";
 import { useSearchParams } from "react-router-dom";
 import { TBook } from "../types/book";
 
@@ -57,10 +57,10 @@ export default function Search() {
         {accumulatedBooks.length > 0 && (
           <Stack>
             {accumulatedBooks.map((book) => (
-              <>
-                <BookCard key={book.id} {...book} />
+              <Fragment key={book.id}>
+                <BookCard {...book} />
                 <Divider size="xs"/>
-              </>
+              </Fragment>
             ))}
           </Stack>
         )}


### PR DESCRIPTION
This PR changes the search function to always search the external api to get more book results. While this may slow down search sometimes, it's done in such a way that, if we have enough search results from the db for a page, then the external search gets queued as a background task, and otherwise it's only called synchronously if there aren't enough results to show. Otherwise users might not see any results for a valid search query. 

This PR also fixes some small visual issues with the search results page, including: 
1. The loading icon appearing at the top of the page when loading a new page, this was impossible to see without scrolling up, now it's where the load more button is 
2. Adds a no more results message once you reach the end of the results 
3. Fixes a console error by adding a fragment with a key when the search results get mapped 